### PR TITLE
Replace deprecated `didChangeAuthorization` status with `locationManagerDidChangeAuthorization`

### DIFF
--- a/LocoKit/Base/LocomotionManager.swift
+++ b/LocoKit/Base/LocomotionManager.swift
@@ -1005,14 +1005,13 @@ import CoreLocation
         locationManagerDelegate?.locationManager?(manager, didExitRegion: region)
     }
     
-    public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         // broadcast a notification
-        let note = Notification(name: .didChangeAuthorizationStatus, object: self, userInfo: ["status": status])
+        let note = Notification(name: .didChangeAuthorizationStatus, object: self, userInfo: ["status": manager.authorizationStatus])
         NotificationCenter.default.post(note)
 
         // forward the delegate event
-        locationManagerDelegate?.locationManager?(manager, didChangeAuthorization: status)
+        locationManagerDelegate?.locationManagerDidChangeAuthorization?(manager)
     }
 
     public func locationManager(_ manager: CLLocationManager, didVisit visit: CLVisit) {

--- a/LocoKit/Base/LocomotionManager.swift
+++ b/LocoKit/Base/LocomotionManager.swift
@@ -1005,6 +1005,13 @@ import CoreLocation
         locationManagerDelegate?.locationManager?(manager, didExitRegion: region)
     }
     
+    @available(iOS, introduced: 4.2, deprecated: 14.0, message: "Use locationManagerDidChangeAuthorization instead")
+    public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        // forward the delegate event
+        locationManagerDelegate?.locationManager?(manager, didChangeAuthorization: status)
+    }
+    
+    @available(iOS 14.0, *)
     public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         // broadcast a notification
         let note = Notification(name: .didChangeAuthorizationStatus, object: self, userInfo: ["status": manager.authorizationStatus])


### PR DESCRIPTION
This pull request addresses the deprecation of the `didChangeAuthorization status` method in iOS 14.0 and replaces it with the new `locationManagerDidChangeAuthorization` method, saving the old implementation if it was used.